### PR TITLE
32 spalte winning team numerisch enkodieren

### DIFF
--- a/filter_matches.py
+++ b/filter_matches.py
@@ -53,7 +53,6 @@ def filter_matches():
     prune_matches_with_early_leavers(match_info_output_path, match_player_output_path)
     split_player_stats(match_player_output_path, match_player_timestamp_path, match_player_general_path)
     replace_hero_ids_with_names(match_player_general_path)
-    print(f"Calling with {match_player_general_path} as player, {match_info_output_path} as info")
     normalize_team_attribute(match_player_general_path, match_info_output_path)
 
 


### PR DESCRIPTION
Aus Issue #33  : OHE aus Notebook überführen nicht notwendig, da schon geschehen mittels Funktion `generate_objectives_time_series` -- außerdem ist das OHE aus dem Notebook nur für Matchende, also sowieso irrelevant für unser Modell.